### PR TITLE
Adding subscribers to wp-admin dashboard widget

### DIFF
--- a/assets/css/style-admin-dashboard.css
+++ b/assets/css/style-admin-dashboard.css
@@ -1,0 +1,36 @@
+.wp-lemme-know-admin-dashboard-list {
+    max-height: 200px;
+    overflow-y: auto;
+    margin-top: 8px;
+}
+
+.wp-lemme-know-admin-dashboard-list table {
+    width: 100%;
+}
+
+.wp-lemme-know-admin-dashboard-list table thead {
+    font-weight: bold;
+    text-align: left;
+}
+
+.wp-lemme-know-admin-dashboard-list table thead tr th {
+    padding: 4px 12px;
+}
+
+.wp-lemme-know-admin-dashboard-list table tbody {
+    color: #646970;
+}
+
+.wp-lemme-know-admin-dashboard-list table tbody tr td {
+    padding: 4px 12px;
+}
+
+.wp-lemme-know-admin-dashboard-list table tbody tr td a:link,
+.wp-lemme-know-admin-dashboard-list table tbody tr td a:visited,
+.wp-lemme-know-admin-dashboard-list table tbody tr td a:hover {
+    text-decoration: none;
+}
+
+.wp-lemme-know-admin-dashboard-list table tbody tr:nth-child(odd) {
+    background: #f6f7f7;
+}

--- a/src/ajax.php
+++ b/src/ajax.php
@@ -56,7 +56,7 @@ function wp_lemme_know_ajax_subscribe_callback()
 {
     global $wpdb;
 
-    $email = strtolower($_POST['email']);
+    $email = esc_html(strtolower($_POST['email']));
     $tableName = $wpdb->prefix . 'lemme_know_subscribers';
 
     header('Content-Type: application/json');

--- a/src/dashboard.php
+++ b/src/dashboard.php
@@ -19,6 +19,12 @@ add_action(
     }
 );
 
+add_action('admin_head', function () {
+    $style = file_get_contents(plugin_dir_path(__FILE__).'../assets/css/style-admin-dashboard.css');
+
+    printf('<style>%s</style>', $style);
+});
+
 function wp_lemme_know_dashboard_callback()
 {
     global $wpdb;
@@ -26,18 +32,18 @@ function wp_lemme_know_dashboard_callback()
     $tableName = $wpdb->prefix . 'lemme_know_subscribers';
     $subscriberCount = $wpdb->get_var(sprintf('SELECT COUNT(*) FROM `%s`', $tableName));
 
-    $subscribers = $wpdb->get_results(sprintf("SELECT `s_email`, `s_date` FROM `%s` WHERE `s_confirmed`='yes' ORDER BY `s_date` DESC", $tableName));
-    $results = [];
-    foreach ($subscribers as $subscriber) {
-        $results[] = [
-            'email' => esc_html($subscriber->s_email),
+    $subscribersResults = $wpdb->get_results(sprintf('SELECT `s_email`, `s_date` FROM `%s` WHERE `s_confirmed`=\'yes\' ORDER BY `s_date` DESC LIMIT 50', $tableName));
+    $subscribers = [];
+    foreach ($subscribersResults as $subscriber) {
+        $subscribers[] = [
+            'email' => $subscriber->s_email,
             'date' => $subscriber->s_date
         ];
     }
 
     $settings = [
         'email_count' => $subscriberCount,
-        'subscribers' => $results
+        'subscribers' => $subscribers
     ];
 
     require_once __DIR__.'/../templates/dashboard.php';

--- a/src/dashboard.php
+++ b/src/dashboard.php
@@ -26,8 +26,18 @@ function wp_lemme_know_dashboard_callback()
     $tableName = $wpdb->prefix . 'lemme_know_subscribers';
     $subscriberCount = $wpdb->get_var(sprintf('SELECT COUNT(*) FROM `%s`', $tableName));
 
+    $subscribers = $wpdb->get_results(sprintf("SELECT `s_email`, `s_date` FROM `%s` WHERE `s_confirmed`='yes' ORDER BY `s_date` DESC", $tableName));
+    $results = [];
+    foreach ($subscribers as $subscriber) {
+        $results[] = [
+            'email' => esc_html($subscriber->s_email),
+            'date' => $subscriber->s_date
+        ];
+    }
+
     $settings = [
-        'email_count' => $subscriberCount
+        'email_count' => $subscriberCount,
+        'subscribers' => $results
     ];
 
     require_once __DIR__.'/../templates/dashboard.php';

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -1,1 +1,7 @@
-<?= sprintf(__('Total count of subscriptions: %d'), $settings['email_count']); ?>
+<?= sprintf(__('Total count of subscriptions: %d'), $settings['email_count']);
+print('<br /><br /><div style="height: 200px; overflow-y: scroll;"><table style="width: 100%;"><thead style="font-weight: bold;"><tr><th>Email address</th><th>Since</td></tr></thead>');
+foreach ($settings['subscribers'] as $subscriber) {
+    printf('<tr><td>%s</td><td><time datetime="%s">%s</time></td></tr>', $subscriber['email'], mysql2date('c', $subscriber['date']), mysql2date(get_option('date_format'), $subscriber['date']));
+}
+print('</table></div>');
+?>

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -1,7 +1,28 @@
-<?= sprintf(__('Total count of subscriptions: %d'), $settings['email_count']);
-print('<br /><br /><div style="height: 200px; overflow-y: scroll;"><table style="width: 100%;"><thead style="font-weight: bold;"><tr><th>Email address</th><th>Since</th></tr></thead>');
-foreach ($settings['subscribers'] as $subscriber) {
-    printf('<tr><td>%s</td><td><time datetime="%s">%s</time></td></tr>', $subscriber['email'], mysql2date('c', $subscriber['date']), mysql2date(get_option('date_format'), $subscriber['date']));
-}
-print('</table></div>');
-?>
+<h3><?= sprintf(__('Total count of subscriptions: %d'), $settings['email_count']) ?></h3>
+
+<?php if (count($settings['subscribers']) > 0): ?>
+    <div class="wp-lemme-know-admin-dashboard-list">
+        <table>
+            <thead>
+                <tr>
+                    <th><?= __('Email address') ?></th>
+                    <th><?= __('Since') ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($settings['subscribers'] as $index => $subscriber): ?>
+                    <tr>
+                        <td><a href="mailto:<?= $subscriber['email'] ?>"><?= $subscriber['email'] ?></a></td>
+                        <td>
+                            <time datetime="<?= mysql2date('c', $subscriber['date']) ?>"><?= sprintf(
+                                '%s, %s',
+                                mysql2date(get_option('date_format'), $subscriber['date']),
+                                mysql2date(get_option('time_format'), $subscriber['date'])
+                            ) ?></time>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+<?php endif ?>

--- a/templates/dashboard.php
+++ b/templates/dashboard.php
@@ -1,5 +1,5 @@
 <?= sprintf(__('Total count of subscriptions: %d'), $settings['email_count']);
-print('<br /><br /><div style="height: 200px; overflow-y: scroll;"><table style="width: 100%;"><thead style="font-weight: bold;"><tr><th>Email address</th><th>Since</td></tr></thead>');
+print('<br /><br /><div style="height: 200px; overflow-y: scroll;"><table style="width: 100%;"><thead style="font-weight: bold;"><tr><th>Email address</th><th>Since</th></tr></thead>');
 foreach ($settings['subscribers'] as $subscriber) {
     printf('<tr><td>%s</td><td><time datetime="%s">%s</time></td></tr>', $subscriber['email'], mysql2date('c', $subscriber['date']), mysql2date(get_option('date_format'), $subscriber['date']));
 }


### PR DESCRIPTION
I found it useful to see the actual email addresses of those who are subscribed, including the date of subscription, on the wp-admin dashboard widget. 